### PR TITLE
use nonbreaking spaces for icon text pairs

### DIFF
--- a/embeds/room_embed.py
+++ b/embeds/room_embed.py
@@ -71,20 +71,20 @@ def room_embed(room: Room, cached_stats: RoomStats = "None", hide_details: bool 
         # Properties
         properties = []
         properties.append(
-            {"description": "Cloning Allowed", "enabled": room.cloning_allowed}
+            {"description": "Cloning\u00a0Allowed", "enabled": room.cloning_allowed}
         )
         properties.append(
-            {"description": "Encrypted Voice Chat", "enabled": room.encrypted_voice_chat}
+            {"description": "Encrypted\u00a0Voice\u00a0Chat", "enabled": room.encrypted_voice_chat}
         )
         properties.append(
-            {"description": "Voice Moderation", "enabled": room.voice_moderated}
+            {"description": "Voice\u00a0Moderation", "enabled": room.voice_moderated}
         )
         properties.sort(key=lambda x: x["enabled"], reverse=True)
 
         properties_text = ""
         for i in properties:
             emoji = get_emoji("correct") if i["enabled"] else get_emoji("incorrect")
-            properties_text += f"`{emoji} {i['description']} ` "
+            properties_text += f"`{emoji}\u00a0{i['description']}\u00a0` "
         
         if details: em.add_field(name="Details", value="\n".join(details), inline=False)
         if properties: em.add_field(name="Properties", value=properties_text, inline=False)

--- a/utils/formatters/format_accessibilities.py
+++ b/utils/formatters/format_accessibilities.py
@@ -7,15 +7,15 @@ ACCESSIBILITY = [
     {"format": "Screen", "icon": get_emoji('screen')},
     {"format": "Walk", "icon": get_emoji('walk')},
     {"format": "Teleport", "icon": get_emoji('teleport')},
-    {"format": "Quest 1", "icon": get_emoji('quest1')},
-    {"format": "Quest 2", "icon": get_emoji('quest2')},
+    {"format": "Quest\u00a01", "icon": get_emoji('quest1')},
+    {"format": "Quest\u00a02", "icon": get_emoji('quest2')},
     {"format": "Mobile", "icon": get_emoji('mobile')},
     {"format": "Juniors", "icon": get_emoji('junior')}
 ]
 
 def format_ele(ele: dict, allowed: bool) -> str:
     emoji = get_emoji("correct") if allowed else get_emoji("incorrect")
-    return f"`{emoji} {ele['format']} `"
+    return f"`{emoji}\u00a0{ele['format']}\u00a0`"
 
 def format_accessibilities(room: Room) -> Tuple[List[str], List[str]]:
     """

--- a/utils/formatters/format_identities.py
+++ b/utils/formatters/format_identities.py
@@ -22,6 +22,6 @@ def format_identities(identities: List[str]) -> List[str]:
     if not identities: return []
     formatted = []
     for ele in identities:
-        formatted.append(f"{IDENTITY_INFO.get(ele, get_emoji('unknown'))} `{ele}`")
+        formatted.append(f"{IDENTITY_INFO.get(ele, get_emoji('unknown'))}\u00a0`{ele}`")
         
     return formatted

--- a/utils/formatters/format_platforms.py
+++ b/utils/formatters/format_platforms.py
@@ -19,6 +19,6 @@ def format_platforms(platforms: List[str]) -> List[str]:
     if not platforms: return []
     formatted = []
     for ele in platforms:
-        formatted.append(f"{get_emoji(ele)} [`{ele}`](<{PLATFORM_URLS.get(ele.lower(), 'https://rec.net/download')}>)")
+        formatted.append(f"{get_emoji(ele)}\u00a0[`{ele}`](<{PLATFORM_URLS.get(ele.lower(), 'https://rec.net/download')}>)")
         
     return formatted

--- a/utils/formatters/format_warnings.py
+++ b/utils/formatters/format_warnings.py
@@ -15,6 +15,6 @@ def format_warnings(warnings: List[str]):
     formatted = []
         
     for ele in warnings:
-        formatted.append(f"{WARNING_ICONS.get(ele, get_emoji('unknown'))} `{ele}`")
+        formatted.append(f"{WARNING_ICONS.get(ele, get_emoji('unknown'))}\u00a0`{ele}`")
             
     return formatted


### PR DESCRIPTION
title is self-explanatory. just to make them look nicer without part of the text and icon breaking off into separate lines. without this pr the nonbreaking spaces can be seen in action in the newly upgraded cv2 chip command for the properties of the chips.